### PR TITLE
update bcrypt dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "async": "0.2.9",
-    "bcrypt": "~0.7.7",
+    "bcrypt": "3.0.6",
     "express": "3.1.0",
     "levenshtein": "1.0.2",
     "moment": "2.0.0",


### PR DESCRIPTION
Older versions of bcrypt arent compatible with up to date versions of node, this fixed the broken npm install I was getting, as far as I can tell the API's TeslaAPI uses (bcrypt.genSaltSync + bcrypt.hashSync) are all compatible